### PR TITLE
feat: Change configuration limit to 8

### DIFF
--- a/modules/nixos/system/boot/bios/default.nix
+++ b/modules/nixos/system/boot/bios/default.nix
@@ -30,7 +30,7 @@ in
           device = "nodev";
           efiSupport = true;
           useOSProber = true;
-          configurationLimit = 5;
+          configurationLimit = 8;
           theme =
             pkgs.fetchFromGitHub
               {


### PR DESCRIPTION
This is for keeping more generations in case I need them in the future.